### PR TITLE
crosslinks for old and new particle and particle emitter db editors s…

### DIFF
--- a/Engine/source/T3D/SceneGroup.cpp
+++ b/Engine/source/T3D/SceneGroup.cpp
@@ -364,51 +364,8 @@ void SceneGroup::unpackUpdate(NetConnection* conn, BitStream* stream)
    }
 }
 
-bool SceneGroup::buildPolyList(PolyListContext context, AbstractPolyList* polyList, const Box3F& box, const SphereF& sphere)
-{
-   Vector<SceneObject*> foundObjects;
-   if (empty())
-   {
-      Con::warnf("SceneGroup::buildPolyList() - SceneGroup %s is empty!", getName());
-      return false;
-   }
-   findObjectByType(foundObjects);
-
-   for (S32 i = 0; i < foundObjects.size(); i++)
-   {
-      foundObjects[i]->buildPolyList(context, polyList, box, sphere);
-   }
-
-   return true;
-}
-
-bool SceneGroup::buildExportPolyList(ColladaUtils::ExportData* exportData, const Box3F& box, const SphereF& sphere)
-{
-   Vector<SceneObject*> foundObjects;
-   findObjectByType(foundObjects);
-
-   for (S32 i = 0; i < foundObjects.size(); i++)
-   {
-      foundObjects[i]->buildExportPolyList(exportData, box, sphere);
-   }
-
-   return true;
-}
-
 void SceneGroup::getUtilizedAssets(Vector<StringTableEntry>* usedAssetsList)
 {
-   //if (empty())
-      return;
-
-   Vector<SceneObject*> foundObjects;
-   findObjectByType(foundObjects);
-
-   for (S32 i = 0; i < foundObjects.size(); i++)
-   {
-      SceneObject* child = foundObjects[i];
-
-      child->getUtilizedAssets(usedAssetsList);
-   }
 }
 
 DefineEngineMethod(SceneGroup, recalculateBounds, void, (), ,

--- a/Engine/source/T3D/SceneGroup.h
+++ b/Engine/source/T3D/SceneGroup.h
@@ -49,8 +49,8 @@ public:
    void reparentOOBObjects();
 
    ///
-   bool buildPolyList(PolyListContext context, AbstractPolyList* polyList, const Box3F& box, const SphereF& sphere) override;
-   bool buildExportPolyList(ColladaUtils::ExportData* exportData, const Box3F& box, const SphereF&) override;
+   bool buildPolyList(PolyListContext context, AbstractPolyList* polyList, const Box3F& box, const SphereF& sphere) override { return false; };
+   bool buildExportPolyList(ColladaUtils::ExportData* exportData, const Box3F& box, const SphereF&) override { return false; };
    void getUtilizedAssets(Vector<StringTableEntry>* usedAssetsList) override;
 };
 #endif

--- a/Engine/source/T3D/assets/ImageAsset.cpp
+++ b/Engine/source/T3D/assets/ImageAsset.cpp
@@ -149,7 +149,6 @@ ImageAsset::ImageAsset() :
    mUseMips(true),
    mIsHDRImage(false),
    mImageType(Albedo),
-   mTextureHandle(NULL),
    mIsNamedTarget(false),
    mImageWidth(-1),
    mImageHeight(-1),
@@ -473,7 +472,8 @@ U32 ImageAsset::load()
          return mLoadedState;
       }
 
-      Con::errorf("ImageAsset::initializeAsset: Attempted to load file %s but it was not valid!", mImageFile);
+      if (mLoadedState != AssetErrCode::BadFileReference && mLoadedState != AssetErrCode::Failed)
+         Con::errorf("ImageAsset::initializeAsset: Attempted to load file %s but it was not valid!", mImageFile);
       mLoadedState = BadFileReference;
       return mLoadedState;
    }
@@ -487,7 +487,15 @@ U32 ImageAsset::load()
 
 GFXTexHandle ImageAsset::getTexture(GFXTextureProfile* requestedProfile)
 {
-   load();
+   if (mLoadedState == Ok && mResourceMap.contains(requestedProfile))
+   {
+      return mResourceMap.find(requestedProfile)->value;
+   }
+   else
+   {
+      //try a reload
+      load();
+   }
 
    if (isNamedTarget())
    {
@@ -499,75 +507,30 @@ GFXTexHandle ImageAsset::getTexture(GFXTextureProfile* requestedProfile)
          tex = getNamedTarget()->getTexture();
          if (tex.isNull())
          {
-            return fallbackAsset->getTexture();
+            return fallbackAsset->getTexture(requestedProfile);
          }
-
+         mResourceMap.insert(requestedProfile, tex);
          return tex;
       }
       else
       {
-         return fallbackAsset->getTexture();
+         return fallbackAsset->getTexture(requestedProfile);
       }
    }
 
    if (mLoadedState == Ok)
    {
-      if (mResourceMap.contains(requestedProfile))
-      {
-         return mResourceMap.find(requestedProfile)->value;
-      }
-      else
-      {
-
          //If we don't have an existing map case to the requested format, we'll just create it and insert it in
          GFXTexHandle newTex;
          newTex.set(mImageFile, requestedProfile, avar("%s %s() - mTextureObject (line %d)", mImageFile, __FUNCTION__, __LINE__));
          if (newTex)
          {
-            mLoadedState = AssetErrCode::Ok;
             mResourceMap.insert(requestedProfile, newTex);
             return newTex;
          }
-      }
    }
-
-   mLoadedState = AssetErrCode::Failed;
 
    return nullptr;
-}
-
-void ImageAsset::generateTexture(void)
-{
-   // already have a generated texture, get out.
-   if (mTextureHandle.isValid())
-      return;
-
-   // implement some defaults, eventually SRGB should be optional.
-   U32 flags = GFXTextureProfile::Static | GFXTextureProfile::SRGB;
-
-   // dont want mips?
-   if (!mUseMips)
-   {
-      flags |= GFXTextureProfile::NoMipmap;
-   }
-
-   GFXTextureProfile::Types type = GFXTextureProfile::Types::DiffuseMap;
-
-   if (mImageType == ImageTypes::Normal) {
-      type = GFXTextureProfile::Types::NormalMap;
-   }
-
-   GFXTextureProfile* genProfile = new GFXTextureProfile("ImageAssetGennedProfile", type, flags);
-
-   mTextureHandle.set(mImageFile, genProfile, avar("%s() - mTextureObject (line %d)", __FUNCTION__, __LINE__));
-   mResourceMap.insert(genProfile, mTextureHandle);
-
-   if (mTextureHandle.isValid())
-      mLoadedState = AssetErrCode::Ok;
-   else
-      mLoadedState = AssetErrCode::Failed;
-
-   ResourceManager::get().getChangedSignal().notify(this, &ImageAsset::_onResourceChanged);
 }
 
 const char* ImageAsset::getImageTypeNameFromType(ImageAsset::ImageTypes type)

--- a/Engine/source/T3D/assets/ImageAsset.h
+++ b/Engine/source/T3D/assets/ImageAsset.h
@@ -136,7 +136,6 @@ private:
    StringTableEntry  mImageFile;
    bool              mUseMips;
    bool              mIsHDRImage;
-   GFXTexHandle      mTextureHandle;
    ImageTypes        mImageType;
    ImageTextureMap   mResourceMap;
    bool              mIsNamedTarget;
@@ -144,8 +143,6 @@ private:
    S32               mImageHeight;
    S32               mImageDepth;
    S32               mImageChannels;
-
-   void generateTexture(void);
 public:
    ImageAsset();
    virtual ~ImageAsset();
@@ -179,7 +176,6 @@ public:
    void                    setTextureHDR(const bool pIsHDR);
    inline bool             getTextureHDR(void) const { return mIsHDRImage; };
 
-   inline GFXTexHandle&    getTexture(void) { load(); generateTexture(); return mTextureHandle; }
    GFXTexHandle            getTexture(GFXTextureProfile* requestedProfile);
 
    static StringTableEntry getImageTypeNameFromType(ImageTypes type);
@@ -188,14 +184,9 @@ public:
    void                    setImageType(ImageTypes type) { mImageType = type; }
    ImageTypes              getImageType() { return mImageType; }
 
-   inline U32              getTextureWidth(void) const { return isAssetValid() ? mTextureHandle->getWidth() : 0; }
-   inline U32              getTextureHeight(void) const { return isAssetValid() ? mTextureHandle->getHeight() : 0; }
-   inline U32              getTextureDepth(void) const { return isAssetValid() ? mTextureHandle->getDepth() : 0; }
-
    inline U32              getTextureBitmapWidth(void) const { return mImageWidth; }
    inline U32              getTextureBitmapHeight(void) const { return mImageHeight; }
    inline U32              getTextureBitmapDepth(void) const { return mImageDepth; }
-   bool                    isAssetValid(void) const override { return !mTextureHandle.isNull(); }
 
    bool                    isNamedTarget(void) const { return mIsNamedTarget; }
    NamedTexTargetRef       getNamedTarget(void) const { return NamedTexTarget::find(mImageFile + 1); }

--- a/Engine/source/T3D/assets/LevelAsset.cpp
+++ b/Engine/source/T3D/assets/LevelAsset.cpp
@@ -227,7 +227,7 @@ StringTableEntry LevelAsset::getPreviewImageAsset() const
 
 StringTableEntry LevelAsset::getPreviewImagePath(void) const
 {
-   if (mPreviewImageAsset.notNull() && mPreviewImageAsset->isAssetValid())
+   if (mPreviewImageAsset.notNull())
    {
       return mPreviewImageAsset->getImageFile();
    }

--- a/Engine/source/core/util/safeDelete.h
+++ b/Engine/source/core/util/safeDelete.h
@@ -34,7 +34,7 @@
 /// @param a Object to delete
 /// @see #SAFE_DELETE_ARRAY(), #SAFE_DELETE_OBJECT(), #SAFE_FREE(), #SAFE_FREE_REFERENCE()
 //-----------------------------------------------------------------------------
-#define SAFE_DELETE(a) {delete (a); (a) = NULL; }
+#define SAFE_DELETE(a) {if((a) != NULL) { delete (a); (a) = NULL; } }
 
 #undef  SAFE_DELETE_ARRAY
 
@@ -44,7 +44,7 @@
 /// @param a Array to delete
 /// @see #SAFE_DELETE(), #SAFE_DELETE_OBJECT(), #SAFE_FREE(), #SAFE_FREE_REFERENCE()
 //-----------------------------------------------------------------------------
-#define SAFE_DELETE_ARRAY(a) { delete [] (a); (a) = NULL; }
+#define SAFE_DELETE_ARRAY(a) { if((a) != NULL) { delete [] (a); (a) = NULL; } }
 
 #undef  SAFE_DELETE_OBJECT
 

--- a/Engine/source/environment/VolumetricFog.cpp
+++ b/Engine/source/environment/VolumetricFog.cpp
@@ -329,8 +329,8 @@ void VolumetricFog::handleResize(VolumetricFogRTManager *RTM, bool resize)
 
       // load texture.
       getTexture();
-      mTexScale.x = 2.0f - ((F32)mTextureAsset->getTextureWidth() / width);
-      mTexScale.y = 2.0f - ((F32)mTextureAsset->getTextureHeight() / height);
+      mTexScale.x = 2.0f - ((F32)mTextureAsset->getTextureBitmapWidth() / width);
+      mTexScale.y = 2.0f - ((F32)mTextureAsset->getTextureBitmapHeight() / height);
    }
 
    UpdateBuffers(0,true);
@@ -1228,8 +1228,8 @@ void VolumetricFog::InitTexture()
       F32 width = (F32)mPlatformWindow->getClientExtent().x;
       F32 height = (F32)mPlatformWindow->getClientExtent().y;
 
-      mTexScale.x = 2.0f - ((F32)mTextureAsset->getTextureWidth() / width);
-      mTexScale.y = 2.0f - ((F32)mTextureAsset->getTextureHeight() / height);
+      mTexScale.x = 2.0f - ((F32)mTextureAsset->getTextureBitmapWidth() / width);
+      mTexScale.y = 2.0f - ((F32)mTextureAsset->getTextureBitmapHeight() / height);
    }
 }
 

--- a/Engine/source/gfx/gfxDevice.cpp
+++ b/Engine/source/gfx/gfxDevice.cpp
@@ -292,7 +292,7 @@ GFXStateBlockRef GFXDevice::createStateBlock(const GFXStateBlockDesc& desc)
    PROFILE_SCOPE( GFXDevice_CreateStateBlock );
 
    U32 hashValue = desc.getHashValue();
-   auto it = mCurrentStateBlocks.find(hashValue);
+   StateBlockMap::Iterator it = mCurrentStateBlocks.find(hashValue);
    if (it != mCurrentStateBlocks.end())
       return it->value;
 

--- a/Engine/source/gfx/gfxDevice.cpp
+++ b/Engine/source/gfx/gfxDevice.cpp
@@ -292,8 +292,9 @@ GFXStateBlockRef GFXDevice::createStateBlock(const GFXStateBlockDesc& desc)
    PROFILE_SCOPE( GFXDevice_CreateStateBlock );
 
    U32 hashValue = desc.getHashValue();
-   if (mCurrentStateBlocks[hashValue])
-      return mCurrentStateBlocks[hashValue];
+   auto it = mCurrentStateBlocks.find(hashValue);
+   if (it != mCurrentStateBlocks.end())
+      return it->value;
 
    GFXStateBlockRef result = createStateBlockInternal(desc);
    result->registerResourceWithDevice(this);   

--- a/Engine/source/gfx/gfxStateBlock.h
+++ b/Engine/source/gfx/gfxStateBlock.h
@@ -36,7 +36,7 @@
 #include "core/color.h"
 #endif
 
-
+#pragma pack(push, 1)
 struct GFXSamplerStateDesc
 {
    GFXTextureAddressMode addressModeU;
@@ -84,8 +84,10 @@ struct GFXSamplerStateDesc
       return !dMemcmp(this, &b, sizeof(GFXSamplerStateDesc));
    }
 };
+#pragma pack(pop)
 
 /// GFXStateBlockDesc defines a render state, which is then used to create a GFXStateBlock instance.  
+#pragma pack(push, 1)
 struct GFXStateBlockDesc
 {   
    // Blending   
@@ -189,6 +191,7 @@ struct GFXStateBlockDesc
    ///
    void setColorWrites( bool red, bool green, bool blue, bool alpha );
 };
+#pragma pack(pop)
 
 class GFXStateBlock : public StrongRefBase, public GFXResource
 {

--- a/Engine/source/gfx/gfxTextureObject.cpp
+++ b/Engine/source/gfx/gfxTextureObject.cpp
@@ -144,7 +144,8 @@ GFXTextureObject::~GFXTextureObject()
 
 void GFXTextureObject::destroySelf()
 {
-   mDevice->mTextureManager->requestDeleteTexture(this);
+   if (mDevice && mDevice->mTextureManager)
+      mDevice->mTextureManager->requestDeleteTexture(this);
 }
 
 //-----------------------------------------------------------------------------

--- a/Engine/source/gui/controls/guiConsole.cpp
+++ b/Engine/source/gui/controls/guiConsole.cpp
@@ -27,6 +27,7 @@
 #include "gui/controls/guiConsole.h"
 #include "gui/containers/guiScrollCtrl.h"
 #include "console/engineAPI.h"
+#include <console/consoleInternal.h>
 
 IMPLEMENT_CONOBJECT(GuiConsole);
 
@@ -145,7 +146,10 @@ void GuiConsole::refreshLogText()
          }
       }
 
+      bool tracing = Con::gTraceOn;
+      Con::gTraceOn = false;
       onNewMessage_callback(errorCount, warnCount, normalCount);
+      Con::gTraceOn = tracing;
    }
 
    Con::unlockLog();

--- a/Engine/source/postFx/postEffect.cpp
+++ b/Engine/source/postFx/postEffect.cpp
@@ -44,6 +44,7 @@
 #include "materials/shaderData.h"
 #include "postFx/postEffectManager.h"
 #include "postFx/postEffectVis.h"
+#include <console/consoleInternal.h>
 
 using namespace Torque;
 
@@ -1126,8 +1127,10 @@ void PostEffect::_setupConstants( const SceneRenderState *state )
             Con::setFloatVariable("$Param::NearDist", state->getNearPlane());
             Con::setFloatVariable("$Param::FarDist", state->getFarPlane());
          }
-
+         bool tracing = Con::gTraceOn;
+         Con::gTraceOn = false;
          setShaderConsts_callback();
+         Con::gTraceOn = tracing;
       }
 
       EffectConstTable::Iterator iter = mEffectConsts.begin();

--- a/Templates/BaseGame/game/data/DamageModel/scripts/server/shapeBase.tscript
+++ b/Templates/BaseGame/game/data/DamageModel/scripts/server/shapeBase.tscript
@@ -268,16 +268,10 @@ function ShapeBaseData::onDestroyed(%this, %obj, %state)
       if (%obj.getMountedImage(%slot))
          %obj.setImageTrigger(%slot, false);
    }
-   
-   if (%obj.client)
-   {
-      %obj.client.player = 0;
-      %obj.client.schedule($DeathDuration, "spawnControlObject");
-   } 
    // Schedule corpse removal. Just keeping the place clean.
    %obj.schedule($CorpseTimeoutValue - 1000, "startFade", 1000, 0, true);
-   %obj.schedule($CorpseTimeoutValue, "delete");
    %obj.schedule($CorpseTimeoutValue,"blowUp");
+   %obj.schedule($CorpseTimeoutValue+32, "delete");
 }
 
 function ShapeBaseData::onRemove(%this, %obj)

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/folder.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/folder.tscript
@@ -1,5 +1,62 @@
 AssetBrowser::registerFileType("FolderObjectType", "Folder", "/", false);
 
+function AssetBrowser::createNewFolder(%this)
+{
+   AssetBrowser_newFolderNameTxt.text = "NewFolder";
+   Canvas.pushDialog(AssetBrowser_newFolder, 99, true);
+
+   AssetBrowser_newFolderNameTxt.selectAllText();
+}
+
+function AssetBrowser::doCreateNewFolder(%this)
+{
+   %newFolderName = AssetBrowser_newFolderNameTxt.getText();
+   
+   if(%newFolderName $= "")
+      %newFolderName = "NewFolder";
+      
+   if(SelectAssetPath.isAwake())
+   {
+      %currentAddressPath = SelectAssetPath-->folderTree.getItemValue(SelectAssetPath.selectedTreeItem) @ "/" @ SelectAssetPath-->folderTree.getItemText(SelectAssetPath.selectedTreeItem);
+   }
+   else
+   {
+      %currentAddressPath = AssetBrowser.dirHandler.currentAddress;
+   }
+      
+   %newFolderIdx = "";
+   %matched = true;
+   %newFolderPath = "";
+   while(%matched == true)
+   {
+      %newFolderPath = %currentAddressPath @ "/" @ %newFolderName @ %newFolderIdx;
+      if(!isDirectory(%newFolderPath))
+      {
+         %matched = false;
+      }
+      else
+      {
+         %newFolderIdx++;         
+      }
+   }
+   
+   //make a dummy file
+   %file = new FileObject();
+   %file.openForWrite(%newFolderPath @ "/test");
+   %file.close();
+   
+   fileDelete(%newFolderPath @ "/test");
+   
+   //refresh the directory
+   AssetBrowser.loadDirectories();
+   
+   %this.navigateTo(%newFolderPath);
+   
+   //On the off chance we're trying to select a path, we'll update the select path window too
+   if(SelectAssetPath.isAwake())
+      SelectAssetPath.showDialog(%newFolderPath, SelectAssetPath.callback);
+}
+
 function FolderObjectType::setupCreateNew()
 {
    AssetBrowser_newFolderNameTxt.text = "NewFolder";

--- a/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/shape.tscript
+++ b/Templates/BaseGame/game/tools/assetBrowser/scripts/assetTypes/shape.tscript
@@ -1,5 +1,38 @@
 AssetBrowser::registerAssetType("ShapeAsset", "Shapes"); 
 
+function ShapeAsset::onCreateNew()
+{
+   %moduleName = $CurrentAssetBrowser.newAssetSettings.moduleName;
+   %modulePath = "data/" @ %moduleName;
+      
+   %assetName = $CurrentAssetBrowser.newAssetSettings.assetName;
+   
+   %assetPath = NewAssetTargetAddress.getText() @ "/";
+   
+   %tamlpath = %assetPath @ %assetName @ ".asset.taml";
+   %shapeFilePath = %assetPath @ %assetName @ ".dae";
+   
+   %asset = new ShapeAsset()
+   {
+      AssetName = %assetName;
+      versionId = 1;
+      friendlyName = $CurrentAssetBrowser.newAssetSettings.friendlyName;
+      description = $CurrentAssetBrowser.newAssetSettings.description;
+      fileName = %assetName @ ".dae";
+   };
+   
+   TamlWrite(%asset, %tamlpath);
+   
+   Canvas.popDialog(AssetBrowser_newComponentAsset);
+	
+	%moduleDef = ModuleDatabase.findModule(%moduleName, 1);
+	AssetDatabase.addDeclaredAsset(%moduleDef, %tamlpath);
+
+	$CurrentAssetBrowser.refresh();
+	
+	return %tamlpath;
+}
+
 function ShapeAsset::onEdit(%this)
 {
    if(EditorSettings.value("Assets/Browser/doubleClickAction", "Edit Asset") $= "Edit Asset")

--- a/Templates/BaseGame/game/tools/particleEditor/nuParticleEditor.ed.tscript
+++ b/Templates/BaseGame/game/tools/particleEditor/nuParticleEditor.ed.tscript
@@ -10,16 +10,20 @@ function ParticleEditorPlugin::BuildEditorUI(%this)
       UIBuilder::TabBook();
          UIBuilder::TabPage("Emitter");
             UIBuilder::Stack();
+               UIBuilder::SameLine();
+                  ParticleEditorPlugin.EmitterSelector = UIBuilder::Dropdown("", %this.selectedEM, "ParticleEditorPlugin.selectEM($ThisControl.getText());");
+                  ParticleEditorPlugin.EmitterSelector.setCanSearch(true);                
+                  %this.PopulateEmitterList();
+               UIBuilder::End();
                %inspector = UIBuilder::Inspector("NuParticleEmitterEdInspector");
             UIBuilder::End();
          UIBuilder::End();
          UIBuilder::TabPage("Particle");
             UIBuilder::Stack();
                UIBuilder::SameLine();
-                  %particlesListCtrl = UIBuilder::Dropdown();
-                  %particlesListCtrl.setCanSearch(true);
-                  %particlesListCtrl.addCategory("Example Module");
-                  %particlesListCtrl.add("A Test Particle");
+                  ParticleEditorPlugin.ParticleSelector = UIBuilder::Dropdown("", %this.selectedPart, "ParticleEditorPlugin.selectPart($ThisControl.getText());");
+                  ParticleEditorPlugin.ParticleSelector.setCanSearch(true);               
+                  %this.PopulateParticleList();
                UIBuilder::End();
                %inspector = UIBuilder::Inspector("NuParticleEdInspector");
             UIBuilder::End();
@@ -40,30 +44,153 @@ function ParticleEditorPlugin::BuildEditorUI(%this)
    EWorldEditor.add(%peWindow);
 }
 
+function ParticleEditorPlugin::PopulateEmitterList()
+{
+    ParticleEditorPlugin.EmitterSelector.add("new ParticleEmitterData");
+    foreach( %obj in DatablockGroup )
+    {
+        if( %obj.isMemberOfClass( "ParticleEmitterData" ) )
+        {
+         %name = %obj.getName();
+         %fileLoc = %obj.getId().getFileName();
+         %fileLoc = strreplace(%fileLoc, "/", " ");
+         %moduleName = getword(%fileLoc,1);
+         ParticleEditorPlugin.EmitterSelector.addCategory(%moduleName);
+         ParticleEditorPlugin.EmitterSelector.add(%name);
+        }
+    }
+}
+
+function ParticleEditorPlugin::PopulateParticleList()
+{
+    if (!isObject(ParticleEditorPlugin.ParticleSelector)) return;
+    
+    ParticleEditorPlugin.ParticleSelector.clear();
+    ParticleEditorPlugin.ParticleSelector.add("new ParticleData");
+    
+    %partCount = 0;
+    %partList = "";
+    
+    if (isObject(ParticleEditorPlugin.curEM))
+    {
+        %partList = ParticleEditorPlugin.curEM.particles;
+        %partCount = getWordCount(%partList);
+    }
+    if (%partCount>0)
+    {
+        for (%i=0; %i<%partCount; %i++)
+        {
+            %obj = getword(%partList, %i);
+            %name = %obj.getName();
+            %fileLoc = %obj.getId().getFileName();
+            %fileLoc = strreplace(%fileLoc, "/", " ");
+            %moduleName = getword(%fileLoc,1);
+            ParticleEditorPlugin.ParticleSelector.addCategory(%moduleName);
+            ParticleEditorPlugin.ParticleSelector.add(%name);
+        }
+    }
+    
+    foreach( %obj in DatablockGroup )
+    {
+        if( %obj.isMemberOfClass( "ParticleData" ) )
+        {            
+            %name = %obj.getName();
+            %fileLoc = %obj.getId().getFileName();
+            %fileLoc = strreplace(%fileLoc, "/", " ");
+            %moduleName = getword(%fileLoc,1);
+            ParticleEditorPlugin.ParticleSelector.addCategory(%moduleName);
+            if (%partCount>0)
+            {
+                %basePart = getword(%partList, 0);
+                if (%basePart.textureAsset !$= %obj.textureAsset) continue;
+            }            
+            ParticleEditorPlugin.ParticleSelector.add(%name);
+        }
+    }
+}
+
 function NuParticleEdInspector::inspectCurrentTargets(%this)
 {
-   %this.inspect(GunFireSmoke);
+   
+   %part = GunFireSmoke;
+   if (EWorldEditor.getSelectionSize()>0)
+   {
+        %obj = EWorldEditor.getSelectedObject(0);
+        if (%obj.isMemberOfClass("ParticleEmitterNode"))
+            $ParticleEditor::emitterNode.sethidden(true);
+        %em = %obj.emitter;
+        %part = getword(%em.particles,0);
+   }
+      
+   %this.inspect(%part);
+   
+   //Remove some groups that aren't particularly relevent to our needs
+   //%this.removeGroup("Internal");
+   //%this.removeGroup("Ungrouped");
+   //%this.removeGroup("Editing");
+   //%this.removeGroup("Object");
+   //%this.removeGroup("Persistence");
+   //%this.removeGroup("Dynamic Fields");
+}
+
+function NuParticleEmitterEdInspector::inspectCurrentTargets(%this)
+{
+   %em = GunFireSmokeEmitter;
+   if (EWorldEditor.getSelectionSize()>0)
+   {
+        %obj = EWorldEditor.getSelectedObject(0);
+        if (%obj.isMemberOfClass("ParticleEmitterNode"))
+            $ParticleEditor::emitterNode.sethidden(true);
+        %em = %obj.emitter;
+   }
+      
+   %this.inspect(%em);
    
    //Remove some groups that aren't particularly relevent to our needs
    %this.removeGroup("Internal");
-   %this.removeGroup("Ungrouped");
+   //%this.removeGroup("Ungrouped");
    %this.removeGroup("Editing");
    %this.removeGroup("Object");
    %this.removeGroup("Persistence");
    %this.removeGroup("Dynamic Fields");
 }
 
-function NuParticleEmitterEdInspector::inspectCurrentTargets(%this)
+function ParticleEditorPlugin::selectEM(%this, %em)
 {
-   %this.inspect(GunFireSmokeEmitter);
+   if (%em $= "new ParticleEmitterData")
+   {
+        PE_EmitterEditor::showNewDialog();
+        return;
+   }
+      
+   if (ParticleEditorPlugin.curEM !$= %em && isObject(%em))
+   {
+      $ParticleEditor::emitterNode.setEmitterDataBlock(%em);
+      ParticleEditorPlugin.curEM = %em;
+      %this.PopulateParticleList();
+      if (isObject(NuParticleEdInspector))
+            NuParticleEmitterEdInspector.inspect(%em);
+   }
    
-   //Remove some groups that aren't particularly relevent to our needs
-   %this.removeGroup("Internal");
-   %this.removeGroup("Ungrouped");
-   %this.removeGroup("Editing");
-   %this.removeGroup("Object");
-   %this.removeGroup("Persistence");
-   %this.removeGroup("Dynamic Fields");
+   //this is stupid. refactor
+   %altID = PEE_EmitterSelector.findText(%em);
+   PEE_EmitterSelector.setSelected(%altID);
+}
+
+function ParticleEditorPlugin::selectPart(%this, %part)
+{
+   if (%part $= "new ParticleData")
+   {
+        PE_ParticleEditor::showNewDialog();
+        return;
+   }
+   
+   if (isObject(NuParticleEdInspector) && isObject(%part))
+      NuParticleEdInspector.inspect(%part);
+   
+   //this is stupid. refactor
+   %altID = PEP_ParticleSelector.findText(%part);
+   PEP_ParticleSelector.setSelected(%altID);
 }
 
 function NuParticleExplosionEdInspector::inspectCurrentTargets(%this)

--- a/Templates/BaseGame/game/tools/particleEditor/nuParticleEditor.ed.tscript
+++ b/Templates/BaseGame/game/tools/particleEditor/nuParticleEditor.ed.tscript
@@ -155,11 +155,46 @@ function NuParticleEmitterEdInspector::inspectCurrentTargets(%this)
    %this.removeGroup("Dynamic Fields");
 }
 
+// Create Functionality
+function ParticleEditorPlugin::showNewEmitterDialog( %this )
+{
+   //FIXME: disregards particle tab dirty state
+
+   // Open a dialog if the current emitter is dirty.
+   
+   if( PE_ParticleEditor.dirty )
+   {         
+      toolsMessageBoxYesNo("Save Existing Particle?", 
+         "Do you want to save changes to <br><br>" @ PE_ParticleEditor.currParticle.getName(), 
+         "PE_ParticleEditor.saveParticle(" @ PE_ParticleEditor.currParticle @ ");"
+      );
+   }   
+   
+   if( PE_EmitterEditor.dirty )
+   {
+      toolsMessageBoxYesNoCancel("Save Emitter Changes?", 
+         "Do you wish to save the changes made to the <br>current emitter before changing the emitter?", 
+         "PE_EmitterEditor.saveEmitter( " @ PE_EmitterEditor.currEmitter.getName() @ " ); PE_EmitterEditor.createEmitter();", 
+         "PE_EmitterEditor.saveEmitterDialogDontSave( " @ PE_EmitterEditor.currEmitter.getName() @ " ); PE_EmitterEditor.createEmitter();"
+      );
+   }
+   else
+   {
+     %this.createEmitter();
+   }
+}
+
+function ParticleEditorPlugin::createEmitter( %this )
+{
+   AssetBrowser_SelectModule.showDialog("PE_EmitterEditor.pickedNewEmitterTargetModule");
+   AssetBrowser_SelectModuleWindow.selectWindow();
+}
+
 function ParticleEditorPlugin::selectEM(%this, %em)
 {
    if (%em $= "new ParticleEmitterData")
    {
-        PE_EmitterEditor::showNewDialog();
+        %this.showNewEmitterDialog();
         return;
    }
       
@@ -177,11 +212,98 @@ function ParticleEditorPlugin::selectEM(%this, %em)
    PEE_EmitterSelector.setSelected(%altID);
 }
 
+function ParticleEditorPlugin::showNewParticleDialog( %this, %replaceSlot )
+{
+   // Open a dialog if the current Particle is dirty
+   if( PE_ParticleEditor.dirty ) 
+   {
+      toolsMessageBoxYesNoCancel("Save Particle Changes?", 
+         "Do you wish to save the changes made to the <br>current particle before changing the particle?", 
+         "PE_ParticleEditor.saveParticle( " @ PE_ParticleEditor.currParticle.getName() @ " ); ParticleEditorPlugin.createParticle( " @ %replaceSlot @ " );", 
+         "PE_ParticleEditor.saveParticleDialogDontSave( " @ PE_ParticleEditor.currParticle.getName() @ " ); ParticleEditorPlugin.createParticle( " @ %replaceSlot @ " );"
+      );
+   }
+   else
+   {
+      %this.createParticle( %replaceSlot );
+   }
+}
+
+function ParticleEditorPlugin::createParticle( %this, %replaceSlot )
+{
+   // Make sure we have a spare slot on the current emitter.
+   
+   if( !%replaceSlot )
+   {
+      %numExistingParticles = getWordCount( PE_EmitterEditor.currEmitter.particles );
+      if( %numExistingParticles > 3 )
+      {
+         toolsMessageBoxOK( "Error", "An emitter cannot have more than 4 particles assigned to it." );
+         return;
+      }
+      
+      %particleIndex = %numExistingParticles;
+   }
+   else
+      %particleIndex = %replaceSlot - 1;
+   
+   PE_ParticleEditor.newParticleSlot = %particleIndex;
+   
+   if(%replaceSlot $= "" || %replaceSlot != 0)
+   {
+      AssetBrowser_SelectModule.showDialog("ParticleEditorPlugin.pickedNewParticleTargetModule");
+      AssetBrowser_SelectModuleWindow.selectWindow();
+   }
+   else
+   {
+      %this.pickedNewParticleTargetModule(PE_EmitterEditor.targetModule);
+   }
+}
+
+function ParticleEditorPlugin::pickedNewParticleTargetModule(%this, %module)
+{
+   %moduleDef = ModuleDatabase.findModule(%module);
+   $PE_PARTICLEEDITOR_DEFAULT_FILENAME = %moduleDef.ModulePath @ "/scripts/managedData/managedParticleData." @ $TorqueScriptFileExtension;
+   
+   if(!isDirectory(filePath($PE_PARTICLEEDITOR_DEFAULT_FILENAME)))
+   {
+      AssetBrowser.dirHandler.createFolder(filePath($PE_PARTICLEEDITOR_DEFAULT_FILENAME));
+   }
+   
+   // Create the particle datablock and add to the emitter.
+   
+   %newParticle = getUniqueName( "newParticle" );
+   
+   datablock ParticleData( %newParticle : DefaultParticle )
+   {
+   };
+         
+   // Submit undo.
+   
+   %action = ParticleEditor.createUndo( ActionCreateNewParticle, "Create New Particle" );
+   %action.particle = %newParticle.getId();
+   %action.particleIndex = PE_ParticleEditor.newParticleSlot;
+   %action.prevParticle = ( "PEE_EmitterParticleSelector" @ ( PE_ParticleEditor.newParticleSlot + 1 ) ).getSelected();
+   %action.emitter = PE_EmitterEditor.currEmitter;
+   
+   if ((ParticleEditorPlugin.curEM.particles $= "") || (ParticleEditorPlugin.curEM.particles $= "DefaultParticle"))
+      ParticleEditorPlugin.curEM.particles = %newParticle.getName();
+   else
+      ParticleEditorPlugin.curEM.particles = ParticleEditorPlugin.curEM.particles SPC %newParticle.getName();
+      
+   NuParticleEmitterEdInspector.inspect(ParticleEditorPlugin.curEM);
+   ParticleEditor.submitUndo( %action );
+   
+   // Execute action.
+   
+   %action.redo();
+}
+
 function ParticleEditorPlugin::selectPart(%this, %part)
 {
    if (%part $= "new ParticleData")
    {
-        PE_ParticleEditor::showNewDialog();
+        %this.showNewParticleDialog();
         return;
    }
    

--- a/Templates/BaseGame/game/tools/particleEditor/particleEmitterEditor.ed.tscript
+++ b/Templates/BaseGame/game/tools/particleEditor/particleEmitterEditor.ed.tscript
@@ -489,6 +489,7 @@ function PE_EmitterEditor::loadNewEmitter( %this, %emitter )
    ParticleEditor.updateEmitterNode();
    
    PE_EmitterEditor-->PEE_infiniteLoop.setStateOn( %current.lifetimeMS == 0 );
+   ParticleEditorPlugin.selectEM(%current);
 }
    
 //---------------------------------------------------------------------------------------------

--- a/Templates/BaseGame/game/tools/particleEditor/particleParticleEditor.ed.tscript
+++ b/Templates/BaseGame/game/tools/particleEditor/particleParticleEditor.ed.tscript
@@ -402,6 +402,7 @@ function PE_ParticleEditor::loadNewParticle( %this, %particle )
 
    PE_ParticleEditor.guiSync();
    PE_ParticleEditor.setParticleNotDirty();
+   ParticleEditorPlugin.selectPart(%particle);
 }
 
 //---------------------------------------------------------------------------------------------

--- a/Templates/BaseGame/game/tools/worldEditor/scripts/menuHandlers.ed.tscript
+++ b/Templates/BaseGame/game/tools/worldEditor/scripts/menuHandlers.ed.tscript
@@ -455,6 +455,10 @@ function EditorAutoSaveMission()
    
    AssetBackupListArray.empty();
    
+   %scenePath = makeFullPath(getRootScene().getFileName());
+   if(startsWith(%scenePath, "tools/levels/")
+      return false;
+   
    //Next, we figure out what all we're planning to save
    %terrainObjects = getRootScene().getObjectsByClass("TerrainBlock", false);
    for(%i=0; %i < getWordCount(%terrainObjects); %i++)


### PR DESCRIPTION
crosslinks for old and new particle and particle emitter db editors so inspector and dropdown sync
replicates only listing particle datablocks used by, (NEW: or sharing the texture used with since that can be added onto the list), a given emitter
still need to sort undo/redo/save